### PR TITLE
Add childcare wizard skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,21 @@
+# Childcare Wizard UI
+
+This example demonstrates a modular multi-step intake form generated from `childcare_form.json` and using the endpoints defined in `childcare_openapi.yaml.txt`.
+
+## Features
+
+- **Modularity**: components are split using an atomic folder structure under `src/components`.
+- **Domain Logic**: form state and visibility rules can be derived from the JSON spec fields such as `visibilityCondition`.
+- **State Store**: form progress and data are managed via Zustand store located in `src/store/formStore.ts`.
+- **Multi-Step Navigation**: the `Stepper` component handles next/back controls and highlights the current step.
+- **RBAC**: `useFormStore` exposes a `role` property. UI elements can check this role to enforce restrictions described in the service's role access map.
+- **Design System**: interactive elements wrap NYC Civic Design System components (see `atoms/`).
+- **Form Lifecycle**: API calls for saving drafts and submission would use the operations described in `childcare_openapi.yaml.txt`.
+- **Testing**: the project is ready for Playwright tests via `npm test`.
+- **Accessibility & Mobile**: components use semantic markup and ARIA attributes where applicable.
+
+Run tests (no real tests included) with:
+
+```bash
+npm test
+```

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "childcare-wizard",
+  "version": "1.0.0",
+  "description": "Multi-step guided intake UI for childcare applications",
+  "scripts": {
+    "test": "playwright test"
+  },
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "zustand": "^4.4.1",
+    "@city-civics/design-system": "^1.0.0"
+  },
+  "devDependencies": {
+    "typescript": "^5.2.2",
+    "playwright": "^1.42.0"
+  }
+}

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,0 +1,6 @@
+import { ButtonHTMLAttributes } from 'react';
+import { Button as DSButton } from '@city-civics/design-system';
+
+export default function Button(props: ButtonHTMLAttributes<HTMLButtonElement>) {
+  return <DSButton {...props} />;
+}

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -1,0 +1,6 @@
+import { InputHTMLAttributes } from 'react';
+import { TextInput } from '@city-civics/design-system';
+
+export default function Input(props: InputHTMLAttributes<HTMLInputElement>) {
+  return <TextInput {...props} />;
+}

--- a/src/components/molecules/Stepper.tsx
+++ b/src/components/molecules/Stepper.tsx
@@ -1,0 +1,33 @@
+import { ReactNode } from 'react';
+import Button from '../atoms/Button';
+import { useFormStore } from '../../store/formStore';
+
+interface StepperProps {
+  steps: { id: string; title: string; content: ReactNode }[];
+}
+
+export default function Stepper({ steps }: StepperProps) {
+  const { stepIndex, next, prev } = useFormStore();
+  const step = steps[stepIndex];
+
+  return (
+    <div>
+      <div role="navigation" aria-label="form-stepper">
+        {steps.map((s, i) => (
+          <span key={s.id} style={{ marginRight: 8, fontWeight: i === stepIndex ? 'bold' : 'normal' }}>
+            {s.title}
+          </span>
+        ))}
+      </div>
+      <div>{step.content}</div>
+      <div style={{ marginTop: 16 }}>
+        <Button onClick={prev} disabled={stepIndex === 0} aria-label="Previous step">
+          Back
+        </Button>
+        <Button onClick={next} aria-label="Next step" style={{ marginLeft: 8 }}>
+          Next
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/organisms/Step.tsx
+++ b/src/components/organisms/Step.tsx
@@ -1,0 +1,16 @@
+import { ReactNode } from 'react';
+
+export interface StepProps {
+  id: string;
+  title: string;
+  children: ReactNode;
+}
+
+export default function Step({ title, children }: StepProps) {
+  return (
+    <section aria-label={title} style={{ marginBottom: '2rem' }}>
+      <h2>{title}</h2>
+      {children}
+    </section>
+  );
+}

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,0 +1,8 @@
+import { createRoot } from 'react-dom/client';
+import ChildcareWizard from './pages/ChildcareWizard';
+
+const container = document.getElementById('root');
+if (container) {
+  const root = createRoot(container);
+  root.render(<ChildcareWizard />);
+}

--- a/src/pages/ChildcareWizard.tsx
+++ b/src/pages/ChildcareWizard.tsx
@@ -1,0 +1,53 @@
+import Stepper from "../components/molecules/Stepper";
+import Step from "../components/organisms/Step";
+import Input from "../components/atoms/Input";
+import { useFormStore } from "../store/formStore";
+
+const formSpec = require("../../childcare_form.json");
+
+function ConsentStep() {
+  return (
+    <Step id="consent" title="Consent">
+      <p>{formSpec.form.steps[0].sections[0].content}</p>
+    </Step>
+  );
+}
+
+function InstructionsStep() {
+  return (
+    <Step id="instructions" title="Instructions">
+      <p>{formSpec.form.steps[1].sections[0].content}</p>
+    </Step>
+  );
+}
+
+function ApplicantInfoStep() {
+  const { updateField, formData } = useFormStore();
+  return (
+    <Step id="applicant" title="Applicant Info">
+      <label htmlFor="firstName">First Name</label>
+      <Input
+        id="firstName"
+        value={(formData as any).firstName || ""}
+        onChange={(e) => updateField("firstName", e.target.value)}
+      />
+    </Step>
+  );
+}
+
+export default function ChildcareWizard() {
+  const steps = [
+    { id: "consent", title: "Consent", content: <ConsentStep /> },
+    {
+      id: "instructions",
+      title: "Instructions",
+      content: <InstructionsStep />,
+    },
+    {
+      id: "applicant",
+      title: "Applicant Info",
+      content: <ApplicantInfoStep />,
+    },
+  ];
+  return <Stepper steps={steps} />;
+}

--- a/src/store/formStore.ts
+++ b/src/store/formStore.ts
@@ -1,0 +1,24 @@
+import create from 'zustand';
+
+export type Role = 'curator' | 'applicant';
+
+export interface FormState {
+  stepIndex: number;
+  formData: Record<string, unknown>;
+  role: Role;
+  loadDraft: (data: Record<string, unknown>) => void;
+  updateField: (path: string, value: unknown) => void;
+  next: () => void;
+  prev: () => void;
+}
+
+export const useFormStore = create<FormState>((set) => ({
+  stepIndex: 0,
+  formData: {},
+  role: 'applicant',
+  loadDraft: (data) => set({ formData: data }),
+  updateField: (path, value) =>
+    set((state) => ({ formData: { ...state.formData, [path]: value } })),
+  next: () => set((state) => ({ stepIndex: state.stepIndex + 1 })),
+  prev: () => set((state) => ({ stepIndex: Math.max(0, state.stepIndex - 1) })),
+}));

--- a/tests/sample.spec.ts
+++ b/tests/sample.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+test("wizard loads", async ({ page }) => {
+  await page.goto("http://localhost:3000");
+  await expect(
+    page.getByRole("navigation", { name: /form-stepper/i }),
+  ).toBeVisible();
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "es2019",
+    "module": "commonjs",
+    "jsx": "react",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- add minimal React+TypeScript scaffold for the childcare form wizard
- include Zustand store, stepper component, and example page
- document project usage in README
- add placeholder Playwright test

## Testing
- `npx prettier -w src/**/*.tsx README.md tests/*.ts package.json tsconfig.json`
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_68582da057108331be45ffe529198339