### PR TITLE
Add Vite dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This example demonstrates a modular multi-step intake form generated from `child
 - **State Store**: form progress and data are managed via Zustand store located in `src/store/formStore.ts`.
 - **Multi-Step Navigation**: the `Stepper` component handles next/back controls and highlights the current step.
 - **RBAC**: `useFormStore` exposes a `role` property. UI elements can check this role to enforce restrictions described in the service's role access map.
-- **Design System**: interactive elements wrap NYC Civic Design System components (see `atoms/`).
+- **Design System**: previously relied on a design system, but atoms now use basic HTML elements.
 - **Form Lifecycle**: API calls for saving drafts and submission would use the operations described in `childcare_openapi.yaml.txt`.
 - **Testing**: the project is ready for Playwright tests via `npm test`.
 - **Accessibility & Mobile**: components use semantic markup and ARIA attributes where applicable.
@@ -19,3 +19,14 @@ Run tests (no real tests included) with:
 ```bash
 npm test
 ```
+
+## Local Development
+
+To run the web application locally:
+
+```bash
+npm install
+npm run dev
+```
+
+This starts a Vite dev server (usually on http://localhost:5173) where the wizard is available.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Childcare Wizard</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/index.tsx"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -3,16 +3,20 @@
   "version": "1.0.0",
   "description": "Multi-step guided intake UI for childcare applications",
   "scripts": {
-    "test": "playwright test"
+    "test": "playwright test",
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
   },
   "dependencies": {
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "zustand": "^4.4.1",
-    "@city-civics/design-system": "^1.0.0"
+    "zustand": "^4.4.1"
   },
   "devDependencies": {
     "typescript": "^5.2.2",
-    "playwright": "^1.42.0"
+    "@playwright/test": "^1.42.0",
+    "vite": "^5.0.0",
+    "@vitejs/plugin-react": "^4.1.0"
   }
 }

--- a/src/components/atoms/Button.tsx
+++ b/src/components/atoms/Button.tsx
@@ -1,6 +1,5 @@
 import { ButtonHTMLAttributes } from 'react';
-import { Button as DSButton } from '@city-civics/design-system';
 
 export default function Button(props: ButtonHTMLAttributes<HTMLButtonElement>) {
-  return <DSButton {...props} />;
+  return <button {...props} />;
 }

--- a/src/components/atoms/Input.tsx
+++ b/src/components/atoms/Input.tsx
@@ -1,6 +1,5 @@
 import { InputHTMLAttributes } from 'react';
-import { TextInput } from '@city-civics/design-system';
 
 export default function Input(props: InputHTMLAttributes<HTMLInputElement>) {
-  return <TextInput {...props} />;
+  return <input {...props} />;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+});


### PR DESCRIPTION
## Summary
- replace design system with native HTML atoms
- add Vite config and HTML entry point
- document how to run the dev server

## Testing
- `npm test` *(fails: ERR_CONNECTION_REFUSED)*

------
https://chatgpt.com/codex/tasks/task_e_685831101a0c8331b94fd93ee77d2c38