### PR TITLE
Fix blank page on dev server

### DIFF
--- a/src/pages/ChildcareWizard.tsx
+++ b/src/pages/ChildcareWizard.tsx
@@ -3,7 +3,7 @@ import Step from "../components/organisms/Step";
 import Input from "../components/atoms/Input";
 import { useFormStore } from "../store/formStore";
 
-const formSpec = require("../../childcare_form.json");
+import formSpec from "../../childcare_form.json";
 
 function ConsentStep() {
   return (

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "dist"
+    "outDir": "dist",
+    "resolveJsonModule": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- fix dev server blank page by importing the JSON config as an ES module
- allow TypeScript to resolve JSON imports

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_685832abb0988331b9a2cb3351e43267