### PR TITLE
Implement dynamic JSON-driven form renderer

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "zustand": "^4.4.1"
   },
   "devDependencies": {
-    "typescript": "^5.2.2",
     "@playwright/test": "^1.42.0",
-    "vite": "^5.0.0",
-    "@vitejs/plugin-react": "^4.1.0"
+    "@types/react": "^19.1.8",
+    "@types/react-dom": "^19.1.6",
+    "@vitejs/plugin-react": "^4.1.0",
+    "typescript": "^5.2.2",
+    "vite": "^5.0.0"
   }
 }

--- a/src/components/FormRenderer.tsx
+++ b/src/components/FormRenderer.tsx
@@ -1,0 +1,187 @@
+import Step from './organisms/Step';
+import Input from './atoms/Input';
+import { useFormStore } from '../store/formStore';
+
+interface Condition {
+  field: string;
+  operator: 'equals' | 'includes';
+  value: unknown;
+}
+
+function evaluateCondition(
+  cond: undefined | Condition | { condition?: Condition }
+): boolean {
+  const { formData } = useFormStore.getState();
+  if (!cond) return true;
+  const c = (cond as any).field ? (cond as Condition) : (cond as any).condition;
+  if (!c) return true;
+  const val = (formData as any)[c.field];
+  switch (c.operator) {
+    case 'equals':
+      return val === c.value;
+    case 'includes':
+      return Array.isArray(val) && val.includes(c.value);
+    default:
+      return true;
+  }
+}
+
+interface FieldSpec {
+  id: string;
+  label?: string;
+  type?: string;
+  fields?: FieldSpec[];
+  ui?: { options?: any[] };
+  metadata?: { multiple?: boolean };
+  visibilityCondition?: Condition;
+}
+
+function FieldRenderer({ field }: { field: FieldSpec }) {
+  const { formData, updateField } = useFormStore();
+  if (!evaluateCondition(field.visibilityCondition)) return null;
+
+  const value = (formData as any)[field.id] ?? '';
+  const opts = field.ui?.options || [];
+
+  switch (field.type) {
+    case 'radio':
+      return (
+        <fieldset>
+          <legend>{field.label}</legend>
+          {opts.map((o: any) => {
+            const val = typeof o === 'string' ? o : o.value;
+            const lbl = typeof o === 'string' ? o : o.label;
+            return (
+              <label key={val} style={{ marginRight: 8 }}>
+                <input
+                  type="radio"
+                  name={field.id}
+                  value={val}
+                  checked={value === val}
+                  onChange={(e) => updateField(field.id, e.target.value)}
+                />
+                {lbl}
+              </label>
+            );
+          })}
+        </fieldset>
+      );
+    case 'select':
+      return (
+        <div>
+          <label htmlFor={field.id}>{field.label}</label>
+          <select
+            id={field.id}
+            value={value}
+            onChange={(e) => updateField(field.id, e.target.value)}
+          >
+            <option value="">Select...</option>
+            {opts.map((o: any) => {
+              const val = typeof o === 'string' ? o : o.value;
+              const lbl = typeof o === 'string' ? o : o.label;
+              return (
+                <option key={val} value={val}>
+                  {lbl}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+      );
+    case 'checkbox':
+      const arr = Array.isArray(value) ? value : [];
+      return (
+        <fieldset>
+          <legend>{field.label}</legend>
+          {opts.map((o: any) => {
+            const val = typeof o === 'string' ? o : o.value;
+            const lbl = typeof o === 'string' ? o : o.label;
+            const checked = arr.includes(val);
+            return (
+              <label key={val} style={{ marginRight: 8 }}>
+                <input
+                  type="checkbox"
+                  value={val}
+                  checked={checked}
+                  onChange={(e) => {
+                    const checked = e.target.checked;
+                    const next = Array.isArray(arr) ? [...arr] : [];
+                    if (checked) {
+                      if (!next.includes(val)) next.push(val);
+                    } else {
+                      const idx = next.indexOf(val);
+                      if (idx !== -1) next.splice(idx, 1);
+                    }
+                    updateField(field.id, next);
+                  }}
+                />
+                {lbl}
+              </label>
+            );
+          })}
+        </fieldset>
+      );
+    default:
+      const type = field.type || 'text';
+      return (
+        <div>
+          <label htmlFor={field.id}>{field.label}</label>
+          <Input
+            id={field.id}
+            type={type as any}
+            value={value as any}
+            onChange={(e) => updateField(field.id, e.target.value)}
+          />
+        </div>
+      );
+  }
+}
+
+interface SectionSpec {
+  id: string;
+  title?: string;
+  type?: string;
+  content?: string;
+  fields?: FieldSpec[];
+  visibilityCondition?: Condition;
+}
+
+function SectionRenderer({ section }: { section: SectionSpec }) {
+  if (!evaluateCondition(section.visibilityCondition)) return null;
+
+  if (section.type === 'info') {
+    return (
+      <section id={section.id} style={{ marginBottom: '1rem' }}>
+        {section.title && <h3>{section.title}</h3>}
+        <p>{section.content}</p>
+      </section>
+    );
+  }
+
+  return (
+    <section id={section.id} style={{ marginBottom: '1rem' }}>
+      {section.title && <h3>{section.title}</h3>}
+      {section.fields?.map((f) => (
+        <FieldRenderer key={f.id} field={f} />
+      ))}
+    </section>
+  );
+}
+
+interface StepSpec {
+  id: string;
+  title: string;
+  sections: SectionSpec[];
+  visibilityCondition?: Condition;
+}
+
+export default function StepRenderer({ step }: { step: StepSpec }) {
+  if (!evaluateCondition(step.visibilityCondition)) return null;
+  return (
+    <Step id={step.id} title={step.title}>
+      {step.sections.map((s) => (
+        <SectionRenderer key={s.id} section={s} />
+      ))}
+    </Step>
+  );
+}

--- a/src/components/molecules/Stepper.tsx
+++ b/src/components/molecules/Stepper.tsx
@@ -8,23 +8,24 @@ interface StepperProps {
 
 export default function Stepper({ steps }: StepperProps) {
   const { stepIndex, next, prev } = useFormStore();
-  const step = steps[stepIndex];
+  const clampedIndex = Math.min(stepIndex, steps.length - 1);
+  const step = steps[clampedIndex];
 
   return (
     <div>
       <div role="navigation" aria-label="form-stepper">
         {steps.map((s, i) => (
-          <span key={s.id} style={{ marginRight: 8, fontWeight: i === stepIndex ? 'bold' : 'normal' }}>
+          <span key={s.id} style={{ marginRight: 8, fontWeight: i === clampedIndex ? 'bold' : 'normal' }}>
             {s.title}
           </span>
         ))}
       </div>
       <div>{step.content}</div>
       <div style={{ marginTop: 16 }}>
-        <Button onClick={prev} disabled={stepIndex === 0} aria-label="Previous step">
+        <Button onClick={prev} disabled={clampedIndex === 0} aria-label="Previous step">
           Back
         </Button>
-        <Button onClick={next} aria-label="Next step" style={{ marginLeft: 8 }}>
+        <Button onClick={next} disabled={clampedIndex === steps.length - 1} aria-label="Next step" style={{ marginLeft: 8 }}>
           Next
         </Button>
       </div>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "compilerOptions": {
     "target": "es2019",
     "module": "commonjs",
-    "jsx": "react",
+    "jsx": "react-jsx",
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,


### PR DESCRIPTION
## Summary
- implement `FormRenderer` for rendering steps/sections/fields from JSON
- generate stepper content from `childcare_form.json`
- clamp active index in `Stepper`
- support new JSX runtime
- add React type dependencies

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: browser download blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685844f3d1a08331b64a9a9b0196131a