### PR TITLE
Add draft persistence and auto save

### DIFF
--- a/src/components/molecules/Stepper.tsx
+++ b/src/components/molecules/Stepper.tsx
@@ -1,7 +1,8 @@
-import { ReactNode } from 'react';
+import { ReactNode, useEffect } from 'react';
 import Button from '../atoms/Button';
 import { useFormStore } from '../../store/formStore';
 import { evaluateCondition } from '../../utils/conditions';
+import { saveDraft } from '../../services/persistence';
 
 interface StepperProps {
   steps: { id: string; title: string; content: ReactNode; spec: any }[];
@@ -37,6 +38,10 @@ export default function Stepper({ steps }: StepperProps) {
   const allValid = requiredIds.every((id) => fieldValid[id]);
   const disableNext = clampedIndex === steps.length - 1 || !allValid;
 
+  useEffect(() => {
+    saveDraft('draft', { formData, stepIndex });
+  }, [stepIndex, formData]);
+
   return (
     <div>
       <div role="navigation" aria-label="form-stepper">
@@ -53,6 +58,13 @@ export default function Stepper({ steps }: StepperProps) {
         </Button>
         <Button onClick={next} disabled={disableNext} aria-label="Next step" style={{ marginLeft: 8 }}>
           Next
+        </Button>
+        <Button
+          onClick={() => saveDraft('draft', { formData, stepIndex })}
+          aria-label="Save draft"
+          style={{ marginLeft: 8 }}
+        >
+          Save for later
         </Button>
       </div>
     </div>

--- a/src/pages/ChildcareWizard.tsx
+++ b/src/pages/ChildcareWizard.tsx
@@ -1,12 +1,20 @@
+import React from "react";
 import Stepper from "../components/molecules/Stepper";
 import StepRenderer from "../components/FormRenderer";
 import { useFormStore } from "../store/formStore";
 import { evaluateCondition } from "../utils/conditions";
+import { loadDraft as fetchDraft } from "../services/persistence";
 
 import formSpec from "../../childcare_form.json";
 
 export default function ChildcareWizard() {
-  const { formData } = useFormStore();
+  const { formData, loadDraft } = useFormStore();
+
+  React.useEffect(() => {
+    fetchDraft().then((data) => {
+      if (data) loadDraft(data);
+    });
+  }, [loadDraft]);
 
   const visibleSteps = formSpec.form.steps.filter((s: any) =>
     evaluateCondition(formData, s.visibilityCondition)

--- a/src/services/persistence.ts
+++ b/src/services/persistence.ts
@@ -1,0 +1,34 @@
+const BASE_URL = 'https://virtserver.swaggerhub.com/mkanpa/ApplicationsService/1.0.0';
+
+export interface DraftData {
+  formData: Record<string, unknown>;
+  stepIndex: number;
+}
+
+export async function loadDraft(applId = 'draft'): Promise<DraftData | null> {
+  try {
+    const res = await fetch(`${BASE_URL}/appl/${applId}`);
+    if (!res.ok) throw new Error('Request failed');
+    const json = await res.json();
+    // Assume API returns { formData, stepIndex }
+    return json;
+  } catch (e) {
+    console.error('loadDraft failed', e);
+    return null;
+  }
+}
+
+export async function saveDraft(
+  applId: string,
+  data: DraftData,
+): Promise<void> {
+  try {
+    await fetch(`${BASE_URL}/appl/${applId}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+  } catch (e) {
+    console.error('saveDraft failed', e);
+  }
+}

--- a/src/store/formStore.ts
+++ b/src/store/formStore.ts
@@ -7,7 +7,7 @@ export interface FormState {
   formData: Record<string, unknown>;
   fieldValid: Record<string, boolean>;
   role: Role;
-  loadDraft: (data: Record<string, unknown>) => void;
+  loadDraft: (data: { formData: Record<string, unknown>; stepIndex?: number }) => void;
   updateField: (path: string, value: unknown) => void;
   setFieldValid: (path: string, valid: boolean) => void;
   next: () => void;
@@ -19,7 +19,8 @@ export const useFormStore = create<FormState>((set) => ({
   formData: {},
   fieldValid: {},
   role: 'applicant',
-  loadDraft: (data) => set({ formData: data }),
+  loadDraft: (data) =>
+    set({ formData: data.formData, stepIndex: data.stepIndex ?? 0 }),
   updateField: (path, value) =>
     set((state) => ({ formData: { ...state.formData, [path]: value } })),
   setFieldValid: (path, valid) =>


### PR DESCRIPTION
## Summary
- implement persistence service for drafts
- populate form store from draft on load
- auto-save drafts on step transitions
- expose Save for later button

## Testing
- `npm test` *(fails: playwright not found)*

------
https://chatgpt.com/codex/tasks/task_e_6858490af0e0833180d64351bf1737ce