### PR TITLE
Add wizard interaction tests

### DIFF
--- a/tests/wizard.spec.ts
+++ b/tests/wizard.spec.ts
@@ -1,0 +1,65 @@
+import { test, expect } from "@playwright/test";
+
+// Utility to mock backend endpoints
+async function mockApi(page) {
+  // Storage for draft data that would normally be persisted
+  let draft: any = null;
+
+  // Intercept load draft call
+  await page.route('**/appl/draft', async route => {
+    if (route.request().method() === 'GET') {
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(draft) });
+    } else {
+      draft = JSON.parse(route.request().postData() || 'null');
+      route.fulfill({ status: 204, body: '' });
+    }
+  });
+
+  // Intercept submission call
+  await page.route('**/appl/draft/submit', route => {
+    route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+  });
+}
+
+test.beforeEach(async ({ page }) => {
+  await mockApi(page);
+});
+
+test('resume from saved draft', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.getByRole('button', { name: /next step/i }).click();
+  await page.getByRole('button', { name: /next step/i }).click();
+  await page.getByLabel('First Name').fill('John');
+  await page.getByLabel('Last Name').fill('Doe');
+  await page.getByRole('button', { name: /save for later/i }).click();
+
+  // Reload should restore state
+  await page.reload();
+  await expect(page.getByLabel('First Name')).toHaveValue('John');
+});
+
+test('conditional fields and role restrictions', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.getByRole('button', { name: /next step/i }).click();
+  await page.getByRole('button', { name: /next step/i }).click();
+
+  // Verify conditional field
+  await page.selectOption('select[name="name_ref"]', 'Other');
+  await expect(page.getByLabel('Other Source (If applicable)')).toBeVisible();
+
+  // Switch role via store (if implemented)
+  await page.evaluate(() => window.useFormStore?.setState({ role: 'curator' }));
+  // Example expectation for curator-only field
+  await expect(page.getByLabel('Curator Notes')).toBeVisible();
+});
+
+test('successful submission', async ({ page }) => {
+  await page.goto('http://localhost:3000');
+  await page.getByRole('button', { name: /next step/i }).click();
+  await page.getByRole('button', { name: /next step/i }).click();
+  await page.getByLabel('First Name').fill('Jane');
+  await page.getByLabel('Last Name').fill('Doe');
+  await page.getByRole('button', { name: /submit application/i }).click();
+  await expect(page.locator('text=Application submitted')).toBeVisible();
+});
+


### PR DESCRIPTION
## Summary
- add `wizard.spec.ts` with mocked API routes
- extend tests for draft resume, conditional fields, role restrictions, and submission

## Testing
- `npm install`
- `npm test` *(fails: browserType.launch: Executable doesn't exist)*

------
https://chatgpt.com/codex/tasks/task_e_6859282b7b688331be758be6ec90dd45